### PR TITLE
Split implementation into separate files

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Features:
 - Thread-safe, so you can call a single instance from as many threads as you want
 - Accepts body data as .NET objects and encodes them for you
 - Can deserialize responses to either a `dynamic` object or to a caller-supplied type
-- [Simple, single-file implementation](Rackspace.CloudOffice/ApiClient.cs)
 
 ### Getting Started
 

--- a/Rackspace.CloudOffice/ApiException.cs
+++ b/Rackspace.CloudOffice/ApiException.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Dynamic;
+using System.IO;
+using System.Net;
+using Newtonsoft.Json;
+
+namespace Rackspace.CloudOffice
+{
+    public class ApiException : Exception
+    {
+        public dynamic Response { get; private set; }
+
+        public ApiException(WebException ex) : base(GetErrorMessage(ex), ex)
+        {
+            var responseStream = ex.Response?.GetResponseStream();
+            if (responseStream == null) return;
+            Response = new StreamReader(responseStream).ReadToEnd();
+            try
+            {
+                Response = JsonConvert.DeserializeObject<ExpandoObject>(Response);
+            }
+            catch
+            {
+            }
+        }
+
+        static string GetErrorMessage(WebException ex)
+        {
+            var r = ex.Response as HttpWebResponse;
+            return r == null
+                ? ex.Message
+                : $"{r.StatusCode:d} - {r.Headers["x-error-message"]}";
+        }
+    }
+}

--- a/Rackspace.CloudOffice/BodyEncoder.cs
+++ b/Rackspace.CloudOffice/BodyEncoder.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+using Newtonsoft.Json;
+
+namespace Rackspace.CloudOffice
+{
+    internal static class BodyEncoder
+    {
+        public static string Encode(object data, string contentType)
+        {
+            switch (contentType)
+            {
+                case ApiClient.ContentType.UrlEncoded: return FormUrlEncode(GetObjectAsDictionary(data));
+                case ApiClient.ContentType.Json:       return JsonConvert.SerializeObject(data);
+                default: throw new ArgumentException("Unsupported contentType: " + contentType);
+            }
+        }
+
+        static string FormUrlEncode(IDictionary<string, string> data)
+        {
+            var pairs = data.Select(pair => string.Format("{0}={1}",
+                WebUtility.UrlEncode(pair.Key),
+                WebUtility.UrlEncode(pair.Value)));
+            return string.Join("&", pairs);
+        }
+
+        static IDictionary<string, string> GetObjectAsDictionary(object obj)
+        {
+            var dict = new Dictionary<string, string>();
+
+            var properties = obj.GetType()
+                .GetMembers(BindingFlags.Public | BindingFlags.Instance)
+                .OfType<PropertyInfo>();
+            foreach (var prop in properties)
+                dict[prop.Name] = Convert.ToString(prop.GetValue(obj));
+
+            return dict;
+        }
+    }
+}

--- a/Rackspace.CloudOffice/IApiClient.cs
+++ b/Rackspace.CloudOffice/IApiClient.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Rackspace.CloudOffice
+{
+    public interface IApiClient
+    {
+        string BaseUrl { get; }
+        string UserKey { get; }
+        IDictionary<string, string> CustomHeaders { get; }
+        Task<dynamic> Get(string path);
+        Task<T> Get<T>(string path);
+        Task<IEnumerable<dynamic>> GetAll(string path, string pagedProperty, int pageSize = 50);
+        Task<IEnumerable<T>> GetAll<T>(string path, string pagedProperty, int pageSize = 50);
+        Task<dynamic> Post(string path, object data, string contentType = ApiClient.ContentType.UrlEncoded);
+        Task<T> Post<T>(string path, object data, string contentType = ApiClient.ContentType.UrlEncoded);
+        Task<dynamic> Put(string path, object data, string contentType = ApiClient.ContentType.UrlEncoded);
+        Task<T> Put<T>(string path, object data, string contentType = ApiClient.ContentType.UrlEncoded);
+        Task Delete(string path);
+    }
+}

--- a/Rackspace.CloudOffice/Rackspace.CloudOffice.csproj
+++ b/Rackspace.CloudOffice/Rackspace.CloudOffice.csproj
@@ -46,7 +46,11 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApiClient.cs" />
+    <Compile Include="ApiException.cs" />
+    <Compile Include="BodyEncoder.cs" />
+    <Compile Include="IApiClient.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Throttler.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Rackspace.CloudOffice/Throttler.cs
+++ b/Rackspace.CloudOffice/Throttler.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace Rackspace.CloudOffice
+{
+    internal class Throttler
+    {
+        public int ThreshholdCount { get; set; }
+        public TimeSpan WindowSize { get; set; }
+
+        DateTime _windowEnd = DateTime.MinValue;
+        int _count;
+
+        public async Task Throttle()
+        {
+            var delay = GetDelay();
+            while (delay > TimeSpan.Zero)
+            {
+                Trace.WriteLine("Throttling");
+                await Task.Delay(delay).ConfigureAwait(false);
+                delay = GetDelay();
+            }
+        }
+
+        TimeSpan GetDelay()
+        {
+            lock (this)
+            {
+                if (DateTime.UtcNow > _windowEnd)
+                {
+                    _windowEnd = DateTime.UtcNow + WindowSize;
+                    _count = 0;
+                }
+
+                _count++;
+                return _count <= ThreshholdCount
+                    ? TimeSpan.Zero
+                    : _windowEnd - DateTime.UtcNow;
+            }
+        }
+    }
+}


### PR DESCRIPTION
The original code was meant to be a replacement for the code sample on the
Cloud Office API wiki, in the sense that it was meant to be dropped-in to
the codebase of someone who wanted to use it.  Now that the recommended
way to include the code is to reference the NuGet package, it no longer
makes sense to keep everything in one file.